### PR TITLE
Cleanup

### DIFF
--- a/board/index.html
+++ b/board/index.html
@@ -107,15 +107,15 @@ shortname: Board
             <div class="col-12 col-md-4">
                 <h4>Long Range Planning</h4>
                 <p>
-                    <b>Co-Chairs:</b> Carolyn Wysinger, Suzanne Ford, & Fred Lopez <abbr title="Executive Director">(ED)</abbr><br>
-                    <b>Members:</b> Bivett Bracket, Diana Oliva, Joshua Smith<br>
+                    <b>Co-Chairs:</b> Carolyn Wysinger, Suzanne Ford, &amp; Fred Lopez <abbr title="Executive Director">(ED)</abbr><br>
+                    <b>Members:</b> Bivett Brackett, Lady Diana Oliva, Joshua Smith<br>
                     <b>Scope:</b> identifying qualified cdeveloping, monitoring and reviewing strategies for long range planning for the organization, including an organizational strategic plan.
                 </p>
             </div>
             <div class="col-12 col-md-4">
                 <h4>Nominating</h4>
                 <p>
-                    <b>Co-Chairs:</b> Carolyn Wysinger & Suzanne Ford <br>
+                    <b>Co-Chairs:</b> Carolyn Wysinger &amp; Suzanne Ford <br>
                     <b>Members:</b> Anajli Rimi<br>
                     <b>Scope:</b> identifying qualified candidates for the board by devising and implementing a plan for strategic board recruitment.
                 </p>
@@ -124,7 +124,7 @@ shortname: Board
                 <h4>Development</h4>
                 <p>
                     <b>Chair:</b> Elizabeth Lanyon<br>
-                    <b>Members:</b> Bivett Brackett, Suzanne Ford, Elizabeth Lanyon, Manuel Perez, Nguyen Pham, Anjali Rimi<br>
+                    <b>Members:</b> Bivett Brackett, Suzanne Ford, Manuel Perez, Nguyen Pham, Anjali Rimi<br>
                     <b>Scope:</b> identifying new funding opportunities for the corporation.
                 </p>
             </div>
@@ -133,15 +133,15 @@ shortname: Board
                 <p>
                     <b>Chair:</b> <br>
                     <b>Members:</b> Nguyen Pham<br>
-                    <b>Scope:</b> identifying qualified candidates for the board by devising and implementing a plan for strategic board recruitment, recommending to the Board of Directors the retention and termination of the independent auditor and negotiating
+                    <b>Scope:</b> recommending to the Board of Directors the retention and termination of the independent auditor and negotiating
                     the independent auditor’s compensation.
                 </p>
             </div>
             <div class="col-12 col-md-6">
                 <h4>Community Affairs</h4>
                 <p>
-                    <b>Co-Chair:</b> Lady Diana and Bivett<br>
-                    <b>Members:</b> Bivett Bracket, Diana Oliva, Joshua Smith<br>
+                    <b>Co-Chair:</b> Lady Diana Oliva &amp; Bivett Brackett<br>
+                    <b>Members:</b> Joshua Smith<br>
                     <b>Scope:</b>
                     <ul>
                         <li>reviewing membership applications and making recommendations to the Board for the acceptance/rejection of applications and for renewals.</li>
@@ -385,7 +385,7 @@ shortname: Board
                 <td>Suzanne Ford</td>
                 <td>Nguyen Pham</td>
                 <td>Anjali Rimi</td>
-                <td>Bivett Brackett, Tuquan Harrison, Elizabeth Lanyon, Kerby Lynch, Diana Oliva, Manuel Perez, Joshua Smith</td>
+                <td>Bivett Brackett, Tuquan Harrison, Elizabeth Lanyon, Kerby Lynch, Lady Diana Oliva, Manuel Perez, Joshua Smith</td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
- correct spelling of several instances of Brackett
- correct omission of "Lady" from Lady Diana Oliva
- use '&amp;' instead of naked ampersand for backward compatibility
- consistently omit chairs from "members" lists
- delete nominating committee text from audit committee description